### PR TITLE
Warning about before template in Dancer 1.3080 fixed.

### DIFF
--- a/lib/Dancer/Plugin/FlashMessage.pm
+++ b/lib/Dancer/Plugin/FlashMessage.pm
@@ -29,7 +29,7 @@ register flash => sub ($;$) {
     return $value;
 };
 
-before_template sub {
+hook before_template => sub {
     shift->{$token_name} = {  map { my $key = $_; my $value;
                                     ( $key, sub { defined $value and return $value;
                                                   my $flash = session($session_hash_key) || {};


### PR DESCRIPTION
Added hook to before_template call to get rid of the depreciation warning

Matt.
