### PR TITLE
Support for Dancer2

### DIFF
--- a/t/02_flash.t
+++ b/t/02_flash.t
@@ -28,6 +28,7 @@ response_content_like( [ GET => '/nothing' ], qr/foo :\s*, message :\s*$/ );
 # first time we get the error message
 route_exists [ GET => '/' ];
 response_content_like( [ GET => '/' ], qr/foo : bar, message : plop$/ );
+
 # second time the error has disappeared
 route_exists [ GET => '/different' ];
 response_content_like( [ GET => '/different' ], qr/foo : bar, message : \s*$/ );

--- a/t/03_retrieve.t
+++ b/t/03_retrieve.t
@@ -4,6 +4,11 @@ use Dancer::Test;
 
 use_ok 'Dancer::Plugin::FlashMessage';
 
-is(flash(foo => 'bar'), 'bar');
-is(flash('foo'), 'bar');
-is(flash('foo'), undef);
+get '/' => sub {
+    
+    is(flash(foo => 'bar'), 'bar');
+    is(flash('foo'), 'bar');
+    is(flash('foo'), undef);
+};
+
+dancer_response GET => '/';

--- a/t/views/index.tt
+++ b/t/views/index.tt
@@ -1,1 +1,1 @@
-foo : <% foo %>, message : <% flash.error %>
+foo : [% foo %], message : [% flash.error %]


### PR DESCRIPTION
These are the needed patches to make it pass against the last version of Dancer2  (master branch on GitHub).

Important note: it can't pass on Dancer 1 and Dancer 2 at the same time because of a change in the arguments passed to registered coderefs in Dancer2 :

In Dancer 1 we did :

   register something => sub { 
      my ($arg1, $arg2) = @_;
   };

In Dancer 2 we have :

   register something => sub { 
      my $dsl = shift;
      my ($arg1, $arg2) = @_;
   };

If we want the plugin to support both versions, we'll need to have some extra code to support both syntax.
